### PR TITLE
Added xdg-utils command to open parsed url on broswer for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Collection of scripts used to bypass 1Fichier time restrictions (PoC).
 
 ## debrid.sh
 
-This script depends on `cURL` and `html-xml-utils`. On Ubuntu, these dependencies
+This script depends on `cURL`, `html-xml-utils` and `xdg-utils`. On Ubuntu, these dependencies
 can be installed by running the following command:
-```$ sudo apt install curl html-xml-utils```
+```$ sudo apt install curl html-xml-utils xdg-utils```
 
 Then, run `debrid.sh` using:
 ```

--- a/debrid.sh
+++ b/debrid.sh
@@ -18,7 +18,7 @@ info() { printf "\33[2K\r$COLOR_INF[*]$COLOR_RES $1" ; }
 #	Validate URL
 # 	-> Get PROXY (from PROXY_FILE)
 #	-> POST to [link] using PROXY, get to download button
-#	-> Parse HTML, grab link
+#	-> Parse HTML, paste link on console and opens it on browser
 debrid() {
 	# (Lazily) Validate URL
 	if [[ "$1" != *"http"* ]]
@@ -48,6 +48,8 @@ debrid() {
 			err "Could not parse direct link"
 		else
 			info "Parsed direct link: $DIRECT\n"
+			if [ "$(uname)" == "Linux" ]; then
+				xdg-open $DIRECT
 			break
 		fi
 	done


### PR DESCRIPTION
The xdg-open command can open a URL automatically on Linux systems, I thought it was a good idea for the user to not need to copy and paste the URL into the browser. I also added a check for this command to run only in Linux environments including Windows WSL 2